### PR TITLE
캘린더 각 일정에 index 부여 v.2 (index > 3 일정들 보여지는 index 재조정)

### DIFF
--- a/src/entities/calendar/api/types.d.ts
+++ b/src/entities/calendar/api/types.d.ts
@@ -10,4 +10,5 @@ export interface Schedule {
   content: string
   startDateTime: string
   endDateTime: string
+  color: string
 }

--- a/src/entities/calendar/consts/constants.ts
+++ b/src/entities/calendar/consts/constants.ts
@@ -1,0 +1,14 @@
+export const DAY_OF_THE_WEEK = ['일', '월', '화', '수', '목', '금', '토']
+
+export const COLORS = {
+  LAVENDER : '#9a9cff',
+  RED : '#dc2227',
+  LIGHT_PURPLE : '#daadfe',
+  LIGHT_BLUE : '#a4bdfd',
+  BLUE : '#5485ee',
+  TEAL : '#47d6dc',
+  MINT : '#7ae7be',
+  GREEN : '#51b749',
+  ORANGE : '#ffb878',
+  LIGHT_GRAY : '#e1e1e1',
+}

--- a/src/entities/calendar/model/scheduleStore.tsx
+++ b/src/entities/calendar/model/scheduleStore.tsx
@@ -1,8 +1,11 @@
 import { ScheduleResponse } from '@/entities/calendar'
 import { addDays, isWithinInterval } from 'date-fns'
 import { create } from 'zustand'
+import { COLORS } from '../consts/constants'
 
 interface IScheduleStore {
+  color: string
+  setColor: (color: string) => void
   title: string | null
   note: string | null
   date: { startDateTime: Date; endDateTime: Date } | null
@@ -28,6 +31,8 @@ interface IScheduleStore {
 }
 
 export const useScheduleStore = create<IScheduleStore>((set) => ({
+  color: COLORS.LIGHT_PURPLE,
+  setColor: (color: string) => set({ color }),
   title: null,
   note: null,
   date: null,

--- a/src/features/calendar/consts/constants.ts
+++ b/src/features/calendar/consts/constants.ts
@@ -1,1 +1,0 @@
-export const DAY_OF_THE_WEEK = ['일', '월', '화', '수', '목', '금', '토']

--- a/src/features/calendar/index.ts
+++ b/src/features/calendar/index.ts
@@ -1,2 +1,2 @@
 export { generateDate } from './lib/utils'
-export { DAY_OF_THE_WEEK } from './consts/constants'
+export { DAY_OF_THE_WEEK } from '../../entities/calendar/consts/constants'

--- a/src/features/calendar/lib/utils.ts
+++ b/src/features/calendar/lib/utils.ts
@@ -11,7 +11,7 @@ import {
   startOfDay,
   startOfMonth,
 } from 'date-fns'
-import { DAY_OF_THE_WEEK } from '../consts/constants'
+import { DAY_OF_THE_WEEK } from '../../../entities/calendar/consts/constants'
 import { ScheduleResponse } from '@/entities/calendar'
 
 interface GenerateDateProps {

--- a/src/shared/ui/input/DateTimeInput.tsx
+++ b/src/shared/ui/input/DateTimeInput.tsx
@@ -1,4 +1,6 @@
+'use client'
 import { format } from 'date-fns'
+import { useRef } from 'react'
 
 interface DateTimeInputProps {
   dateTime: Date
@@ -11,10 +13,35 @@ export const DateTimeInput = ({
   handleDateChange,
   handleTimeChange,
 }: DateTimeInputProps) => {
+  const dateInputRef = useRef<HTMLInputElement>(null)
+  const timeInputRef = useRef<HTMLInputElement>(null)
+
+  const handleDateClick = () => {
+    dateInputRef.current?.showPicker()
+  }
+
+  const handleTimeClick = () => {
+    timeInputRef.current?.showPicker()
+  }
+
   return (
     <div className="flex flex-1 flex-col">
-      <input type="date" value={format(dateTime, 'yyyy-MM-dd')} onChange={handleDateChange} />
-      <input type="time" value={format(dateTime, 'HH:mm')} onChange={handleTimeChange} />
+      <input
+        ref={dateInputRef}
+        type="date"
+        value={format(dateTime, 'yyyy-MM-dd')}
+        onChange={handleDateChange}
+        onClick={handleDateClick}
+        className="cursor-pointer"
+      />
+      <input
+        ref={timeInputRef}
+        type="time"
+        value={format(dateTime, 'HH:mm')}
+        onChange={handleTimeChange}
+        onClick={handleTimeClick}
+        className="cursor-pointer"
+      />
     </div>
   )
 }

--- a/src/views/calendar/ui/AddEvent/AddEvent.tsx
+++ b/src/views/calendar/ui/AddEvent/AddEvent.tsx
@@ -3,6 +3,7 @@
 import AddEventTitle from './AddScheduleTitle'
 import AddEventTime from './AddScheduleTime'
 import AddEventNote from './AddScheduleNote'
+import AddScheduleColor from './AddScheduleColor'
 import { useParams, useRouter } from 'next/navigation'
 import { useMutation, useQuery } from '@tanstack/react-query'
 import {
@@ -23,6 +24,7 @@ import { BaseButton, BaseHeader, LoadingSpinner } from '@/shared/ui'
 import AddEventLocation from './AddScheduleLocation'
 import { COLORS } from '@/entities/calendar/consts/constants'
 
+
 /**
  * id 있다면 : 스케쥴 수정
  * id 없다면 : 스케쥴 생성
@@ -32,6 +34,8 @@ export function AddEventPage() {
     title,
     note,
     date,
+    color,
+    setColor,
     setTitle,
     setNote,
     setDate,
@@ -99,13 +103,15 @@ export function AddEventPage() {
         startDateTime: new Date(scheduleDetailData.startDateTime),
         endDateTime: new Date(scheduleDetailData.endDateTime),
       })
+      setColor(scheduleDetailData.color)
     }
     return () => {
       setTitle(null)
       setNote(null)
       setDate(null)
+      setColor(COLORS.LIGHT_PURPLE)
     }
-  }, [scheduleDetailData, setTitle, setNote, setDate, scheduleId])
+  }, [scheduleDetailData, setColor, setTitle, setNote, setDate, scheduleId])
 
   /**
    * Schedule 저장
@@ -119,7 +125,7 @@ export function AddEventPage() {
       location: '',
       startDateTime: format(date?.startDateTime || new Date(baseDate), "yyyy-MM-dd'T'HH:mm:ss"),
       endDateTime: format(date?.endDateTime || new Date(baseDate), "yyyy-MM-dd'T'HH:mm:ss"),
-      color: findKeyByValue(color),
+      color: findKeyByValue(color) || 'LIGHT_PURPLE',
     }
 
     //시작시간이 끝나는 시간보다 클 경우
@@ -138,29 +144,12 @@ export function AddEventPage() {
     deleteMutation.mutate()
   }
 
-  // 임시 color 부여 로직
-  const [color, setColor] = useState(COLORS.LIGHT_PURPLE)
 
-  const onClickColor = (color: string) => {
-    handleColorChange(color)
-    setIsColorPickerOpen(false)
-  }
-
-  const handleColorChange = (color: string) => {
-    setColor(color)
-  }
-
-  const [isColorPickerOpen, setIsColorPickerOpen] = useState(false)
-
-  const handleColorPickerToggle = () => {
-    setIsColorPickerOpen(!isColorPickerOpen)
-  }
 
   // color 의 key 찾기
-  const findKeyByValue = (value: string) => {
-    return Object.keys(COLORS).find((key) => COLORS[key] === value)
+  const findKeyByValue = (color: string) => {
+    return Object.keys(COLORS).find((key) => COLORS[key as keyof typeof COLORS] === color)
   }
-
 
   if (isLoading) return <LoadingSpinner />
   if (isError) alert(error)
@@ -186,25 +175,8 @@ export function AddEventPage() {
       <div className="flex flex-col px-[1.5rem] overflow-hidden py-[1.5rem] h-[75vh] ">
         <div className="flex flex-col flex-grow overflow-y-auto gap-[3rem] ">
           <div className='relative flex justify-between items-center'>
-          <AddEventTitle placeholder={'Title'} />
-          <div className='w-[1em] h-[1em] rounded-full cursor-pointer' 
-          style={{ backgroundColor: color }} 
-          onClick={handleColorPickerToggle}
-          />
-          {
-            isColorPickerOpen && (
-              <div className='absolute top-[30px] right-[5px] grid grid-cols-5 p-[10px] gap-[0.5em] rounded-[20px] bg-white shadow-[0_2px_8px_rgba(0,0,0,0.1)]'>
-                {Object.values(COLORS).map((color) => (
-                  <div
-                    key={`plan-color-${color}`}
-                    className='w-[1em] h-[1em] rounded-full cursor-pointer'
-                    style={{ backgroundColor: color }}
-                    onClick={() => onClickColor(color)}
-                  />
-                ))}
-              </div>
-            )
-          }
+            <AddEventTitle placeholder={'Title'} />
+            <AddScheduleColor />
           </div>
           <AddEventTime />
           <AddEventLocation />

--- a/src/views/calendar/ui/AddEvent/AddEvent.tsx
+++ b/src/views/calendar/ui/AddEvent/AddEvent.tsx
@@ -14,13 +14,14 @@ import {
   postSchedule,
   putSchedule,
 } from '@/entities/calendar'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { AxiosError } from 'axios'
 import { format } from 'date-fns'
 import { compareDesc } from 'date-fns/fp'
 import Image from 'next/image'
 import { BaseButton, BaseHeader, LoadingSpinner } from '@/shared/ui'
 import AddEventLocation from './AddScheduleLocation'
+import { COLORS } from '@/entities/calendar/consts/constants'
 
 /**
  * id 있다면 : 스케쥴 수정
@@ -118,6 +119,7 @@ export function AddEventPage() {
       location: '',
       startDateTime: format(date?.startDateTime || new Date(baseDate), "yyyy-MM-dd'T'HH:mm:ss"),
       endDateTime: format(date?.endDateTime || new Date(baseDate), "yyyy-MM-dd'T'HH:mm:ss"),
+      color: findKeyByValue(color),
     }
 
     //시작시간이 끝나는 시간보다 클 경우
@@ -135,6 +137,30 @@ export function AddEventPage() {
   const handleDeleteButton = () => {
     deleteMutation.mutate()
   }
+
+  // 임시 color 부여 로직
+  const [color, setColor] = useState(COLORS.LIGHT_PURPLE)
+
+  const onClickColor = (color: string) => {
+    handleColorChange(color)
+    setIsColorPickerOpen(false)
+  }
+
+  const handleColorChange = (color: string) => {
+    setColor(color)
+  }
+
+  const [isColorPickerOpen, setIsColorPickerOpen] = useState(false)
+
+  const handleColorPickerToggle = () => {
+    setIsColorPickerOpen(!isColorPickerOpen)
+  }
+
+  // color 의 key 찾기
+  const findKeyByValue = (value: string) => {
+    return Object.keys(COLORS).find((key) => COLORS[key] === value)
+  }
+
 
   if (isLoading) return <LoadingSpinner />
   if (isError) alert(error)
@@ -159,7 +185,27 @@ export function AddEventPage() {
       />
       <div className="flex flex-col px-[1.5rem] overflow-hidden py-[1.5rem] h-[75vh] ">
         <div className="flex flex-col flex-grow overflow-y-auto gap-[3rem] ">
+          <div className='relative flex justify-between item-center'>
           <AddEventTitle placeholder={'Title'} />
+          <div className='w-[1em] h-[1em] rounded-full cursor-pointer' 
+          style={{ backgroundColor: color }} 
+          onClick={handleColorPickerToggle}
+          />
+          {
+            isColorPickerOpen && (
+              <div className='absolute top-[30px] right-[5px] grid grid-cols-5 p-[10px] gap-[0.5em] rounded-[20px] bg-white shadow-[0_2px_8px_rgba(0,0,0,0.1)]'>
+                {Object.values(COLORS).map((color) => (
+                  <div
+                    key={`plan-color-${color}`}
+                    className='w-[1em] h-[1em] rounded-full cursor-pointer'
+                    style={{ backgroundColor: color }}
+                    onClick={() => onClickColor(color)}
+                  />
+                ))}
+              </div>
+            )
+          }
+          </div>
           <AddEventTime />
           <AddEventLocation />
           <AddEventNote />

--- a/src/views/calendar/ui/AddEvent/AddEvent.tsx
+++ b/src/views/calendar/ui/AddEvent/AddEvent.tsx
@@ -185,7 +185,7 @@ export function AddEventPage() {
       />
       <div className="flex flex-col px-[1.5rem] overflow-hidden py-[1.5rem] h-[75vh] ">
         <div className="flex flex-col flex-grow overflow-y-auto gap-[3rem] ">
-          <div className='relative flex justify-between item-center'>
+          <div className='relative flex justify-between items-center'>
           <AddEventTitle placeholder={'Title'} />
           <div className='w-[1em] h-[1em] rounded-full cursor-pointer' 
           style={{ backgroundColor: color }} 

--- a/src/views/calendar/ui/AddEvent/AddScheduleColor.tsx
+++ b/src/views/calendar/ui/AddEvent/AddScheduleColor.tsx
@@ -1,0 +1,47 @@
+import { useScheduleStore } from "@/entities/calendar"
+import { COLORS } from "@/entities/calendar/consts/constants"
+import { useState } from "react"
+
+const AddScheduleColor = () => {
+    const { color, setColor } = useScheduleStore()
+
+    const onClickColor = (color: string) => {
+        handleColorChange(color)
+        setIsColorPickerOpen(false)
+    }
+
+    const handleColorChange = (color: string) => {
+        setColor(color)
+    }
+
+    const [isColorPickerOpen, setIsColorPickerOpen] = useState(false)
+
+    const handleColorPickerToggle = () => {
+        setIsColorPickerOpen(!isColorPickerOpen)
+    }
+
+    return (
+        <>
+            <div className='w-[1em] h-[1em] rounded-full cursor-pointer'
+                style={{ backgroundColor: color }}
+                onClick={handleColorPickerToggle}
+            />
+            {
+                isColorPickerOpen && (
+                    <div className='absolute top-[30px] right-[5px] grid grid-cols-5 p-[10px] gap-[0.5em] rounded-[20px] bg-white shadow-[0_2px_8px_rgba(0,0,0,0.1)]'>
+                        {Object.values(COLORS).map((color) => (
+                            <div
+                                key={`plan-color-${color}`}
+                                className='w-[1em] h-[1em] rounded-full cursor-pointer'
+                                style={{ backgroundColor: color }}
+                                onClick={() => onClickColor(color)}
+                            />
+                        ))}
+                    </div>
+                )
+            }
+        </>
+    )
+}
+
+export default AddScheduleColor

--- a/src/views/calendar/ui/AddEvent/AddScheduleTime.tsx
+++ b/src/views/calendar/ui/AddEvent/AddScheduleTime.tsx
@@ -26,11 +26,11 @@ const AddEventTime = () => {
       [`${type}DateTime`]:
         mode === 'date'
           ? new Date(
-              `${value}T${format(date ? new Date(currentDate[`${type}DateTime`]) : new Date(), 'HH:mm')}`,
-            )
+            `${value}T${format(date ? new Date(currentDate[`${type}DateTime`]) : new Date(), 'HH:mm')}`,
+          )
           : new Date(
-              `${format(date ? new Date(currentDate[`${type}DateTime`]) : new Date(), 'yyyy-MM-dd')}T${value}`,
-            ),
+            `${format(date ? new Date(currentDate[`${type}DateTime`]) : new Date(), 'yyyy-MM-dd')}T${value}`,
+          ),
     }
 
     setDate(updatedDate)

--- a/src/views/calendar/ui/Calendar/CalendarHeader.tsx
+++ b/src/views/calendar/ui/Calendar/CalendarHeader.tsx
@@ -11,7 +11,7 @@ const CalendarHeader = () => {
         src="/images/icon/doubleArrow.png"
         width={24}
         height={24}
-        className="rotate-180"
+        className="rotate-180 cursor-pointer"
         onClick={() => {
           setCurrentDate(addYears(currentDate, -1))
         }}
@@ -21,7 +21,7 @@ const CalendarHeader = () => {
         src="/images/icon/arrow.png"
         width={24}
         height={24}
-        className="rotate-180"
+        className="rotate-180 cursor-pointer"
         onClick={() => {
           setCurrentDate(addMonths(currentDate, -1))
         }}
@@ -34,6 +34,7 @@ const CalendarHeader = () => {
         src="/images/icon/arrow.png"
         width={24}
         height={24}
+        className="cursor-pointer"
         onClick={() => {
           setCurrentDate(addMonths(currentDate, +1))
         }}
@@ -43,6 +44,7 @@ const CalendarHeader = () => {
         src="/images/icon/doubleArrow.png"
         width={24}
         height={24}
+        className="cursor-pointer"
         onClick={() => {
           setCurrentDate(addYears(currentDate, +1))
         }}

--- a/src/views/calendar/ui/Calendar/DetailModal.tsx
+++ b/src/views/calendar/ui/Calendar/DetailModal.tsx
@@ -1,4 +1,5 @@
 import { useScheduleStore } from '@/entities/calendar'
+import { COLORS } from '@/entities/calendar/consts/constants'
 import {
   getFormattedDate,
   getFormattedDay,
@@ -63,7 +64,7 @@ const DetailModal = ({ isVisable, closeDetailModal, date }: Props) => {
             >
               <div className="flex gap-2">
                 <div className="h-6 flex justify-center items-center">
-                  <div className="w-2 h-2 rounded-full bg-red-500" />
+                  <div className="w-2 h-2 rounded-full" style={{ backgroundColor: COLORS[plan.color as keyof typeof COLORS] || COLORS['LIGHT_PURPLE'] }} />
                 </div>
                 <div>
                   <div className="text-2xl h-6 align-middle">{plan.title}</div>

--- a/src/views/calendar/ui/Calendar/ScheduleList.tsx
+++ b/src/views/calendar/ui/Calendar/ScheduleList.tsx
@@ -24,23 +24,23 @@ const ScheduleList = ({ date }: ScheduleList) => {
   const checkIndex = (index: number): number => {
     // index가 3보다 작으면 그대로 반환
     if (index < 3) return index
-    
+
     // 사용 중인 인덱스 배열 생성 (0, 1, 2만 확인)
     const usedIndices = sortedOneDaySchedule
       .map(plan => plan.index)
       .filter(idx => idx < 3)
-    
+
     // 3 이상인 인덱스를 가진 plan들을 찾아서 순서대로 정렬
     const highIndexPlans = sortedOneDaySchedule
       .filter(plan => plan.index >= 3)
       .sort((a, b) => a.index - b.index)
-    
+
     // 현재 plan의 위치 찾기 (index 3부터 시작하는 순서)
     const highIndexPosition = highIndexPlans.findIndex(plan => plan.index === index)
-    
+
     // 사용 가능한 낮은 인덱스들 (0, 1, 2 중에서 사용되지 않은 것들)
     const availableIndices = [0, 1, 2].filter(idx => !usedIndices.includes(idx))
-    
+
     // 사용 가능한 인덱스가 있고, 현재 plan의 위치가 유효하면
     if (availableIndices.length > 0 && highIndexPosition !== -1) {
       // 위치에 따라 사용 가능한 인덱스 할당 (순서대로)
@@ -48,7 +48,7 @@ const ScheduleList = ({ date }: ScheduleList) => {
         return availableIndices[highIndexPosition]
       }
     }
-    
+
     // 사용 가능한 인덱스가 없거나, 모든 낮은 인덱스가 이미 재할당된 경우 원래 인덱스 반환
     return index
   }
@@ -60,9 +60,9 @@ const ScheduleList = ({ date }: ScheduleList) => {
           <li
             key={plan.id}
             className="absolute h-1/4 text-[0.5rem] text-ellipsis overflow-hidden w-full whitespace-nowrap px-[0.5rem] text-sm"
-            style={{ 
+            style={{
               top: `calc(${25 * checkIndex(plan.index)}% + ${2 * checkIndex(plan.index) + 2}px)`,
-              backgroundColor: COLORS[plan.color as keyof typeof COLORS] || '#FFA4AA'
+              backgroundColor: COLORS[plan.color as keyof typeof COLORS] || COLORS['LIGHT_PURPLE']
             }}
           >
             <div>

--- a/src/views/calendar/ui/Calendar/ScheduleList.tsx
+++ b/src/views/calendar/ui/Calendar/ScheduleList.tsx
@@ -1,4 +1,5 @@
 import { useScheduleStore } from '@/entities/calendar'
+import { COLORS } from '@/entities/calendar/consts/constants'
 import {
   getOneDaySchedule,
   getSortedOneDaySchedule,
@@ -58,8 +59,11 @@ const ScheduleList = ({ date }: ScheduleList) => {
         return (
           <li
             key={plan.id}
-            className={`absolute h-1/4 bg-pink text-[0.5rem] text-ellipsis overflow-hidden w-full whitespace-nowrap px-[0.5rem] text-sm`}
-            style={{ top: `calc(${25 * checkIndex(plan.index)}% + ${2 * checkIndex(plan.index) + 2}px)` }}
+            className="absolute h-1/4 text-[0.5rem] text-ellipsis overflow-hidden w-full whitespace-nowrap px-[0.5rem] text-sm"
+            style={{ 
+              top: `calc(${25 * checkIndex(plan.index)}% + ${2 * checkIndex(plan.index) + 2}px)`,
+              backgroundColor: COLORS[plan.color as keyof typeof COLORS] || '#FFA4AA'
+            }}
           >
             <div>
               <span>

--- a/src/views/calendar/ui/Calendar/ScheduleList.tsx
+++ b/src/views/calendar/ui/Calendar/ScheduleList.tsx
@@ -18,6 +18,40 @@ const ScheduleList = ({ date }: ScheduleList) => {
   // 일정이 긴 plan 순서대로 display
   const sortedOneDaySchedule = getSortedOneDaySchedule(oneDaySchedule)
 
+  // 일정의 index를 재계산하는 함수
+  // 만약 index가 3보다 크고, 해당 날짜에 index 0,1,2가 없으면 차례대로 index를 다시 계산
+  const checkIndex = (index: number): number => {
+    // index가 3보다 작으면 그대로 반환
+    if (index < 3) return index
+    
+    // 사용 중인 인덱스 배열 생성 (0, 1, 2만 확인)
+    const usedIndices = sortedOneDaySchedule
+      .map(plan => plan.index)
+      .filter(idx => idx < 3)
+    
+    // 3 이상인 인덱스를 가진 plan들을 찾아서 순서대로 정렬
+    const highIndexPlans = sortedOneDaySchedule
+      .filter(plan => plan.index >= 3)
+      .sort((a, b) => a.index - b.index)
+    
+    // 현재 plan의 위치 찾기 (index 3부터 시작하는 순서)
+    const highIndexPosition = highIndexPlans.findIndex(plan => plan.index === index)
+    
+    // 사용 가능한 낮은 인덱스들 (0, 1, 2 중에서 사용되지 않은 것들)
+    const availableIndices = [0, 1, 2].filter(idx => !usedIndices.includes(idx))
+    
+    // 사용 가능한 인덱스가 있고, 현재 plan의 위치가 유효하면
+    if (availableIndices.length > 0 && highIndexPosition !== -1) {
+      // 위치에 따라 사용 가능한 인덱스 할당 (순서대로)
+      if (highIndexPosition < availableIndices.length) {
+        return availableIndices[highIndexPosition]
+      }
+    }
+    
+    // 사용 가능한 인덱스가 없거나, 모든 낮은 인덱스가 이미 재할당된 경우 원래 인덱스 반환
+    return index
+  }
+
   return (
     <ul className="relative h-calc24">
       {sortedOneDaySchedule.slice(0, 3).map((plan) => {
@@ -25,11 +59,10 @@ const ScheduleList = ({ date }: ScheduleList) => {
           <li
             key={plan.id}
             className={`absolute h-1/4 bg-pink text-[0.5rem] text-ellipsis overflow-hidden w-full whitespace-nowrap px-[0.5rem] text-sm`}
-            style={{ top: `calc(${25 * plan.index}% + ${2 * plan.index + 2}px)` }}
+            style={{ top: `calc(${25 * checkIndex(plan.index)}% + ${2 * checkIndex(plan.index) + 2}px)` }}
           >
             <div>
               <span>
-                {/* {isStartDate(plan.startDateTime, date) ? trancateString(plan.title, 7) : ''} */}
                 {trancateString(plan.title, 7)}
               </span>
             </div>


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제가 무엇인가요?

- index > 3 일정이 특정 날짜에 범위를 넘어가는 기존 로직의 한계가 있어 수정했습니다
아래의 2222 일정은 6일부터 8일까지의 일정인데 6일에서 index를 4를 부여받았습니다 
그런데 7~8일에는 일정이 1개여서 +more  처리가 되지 않아 index 4의 높이 값으로 캘린더에 반영되는 UI 버그가 있었습니다.
![image](https://github.com/user-attachments/assets/83ff13d5-1b64-45e5-858b-47b981e24c7f)

## ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?

- index > 3 일정은 index 재조정을 거칩니다.
![image](https://github.com/user-attachments/assets/fca65c5a-49e5-43fb-ac1c-703d79e06ece)


## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분이 있나요?

- 일정에 color 를 추가했습니다

## 🩺 이 PR에서 테스트 혹은 검증이 필요한 부분이 있을까요?

- index 재조정 부분은 단위 테스트 코드를 작성할 예정입니다

##### 📌 PR 진행 시 이러한 점들을 참고해 주세요

```
- Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
- Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
- Review는 특수한 케이스가 아니면 Reviewer로 지정된 시점 기준으로 7일 이내에 진행해 주세요.
- Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    - P1 : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    - P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
    - P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)
```

