### PR TITLE
Feature/hotfix

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -5,8 +5,7 @@
 @layer base {
   @font-face {
     font-family: 'GangwonEduSaeeum_OTFMediumA';
-    src: url('https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_2201-2@1.0/GangwonEduSaeeum_OTFMediumA.woff')
-      format('woff');
+    src: url('https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_2201-2@1.0/GangwonEduSaeeum_OTFMediumA.woff') format('woff');
     font-weight: normal;
     font-style: normal;
   }
@@ -16,9 +15,11 @@
   .h-calc64 {
     height: calc(100% - 64px);
   }
+
   .h-calc24 {
     height: calc(100% - 24px);
   }
+
   .h-calc4rem {
     height: calc(100% - 4rem);
   }
@@ -29,12 +30,13 @@
   --foreground: #171717;
 }
 
-@media (prefers-color-scheme: dark) {
+/* 아직 다크 모드 지원 안해서 주석처리 */
+/* @media (prefers-color-scheme: dark) {
   :root {
     --background: #0a0a0a;
     --foreground: #ededed;
   }
-}
+} */
 
 body {
   color: var(--foreground);

--- a/src/entities/calendar/api/index.ts
+++ b/src/entities/calendar/api/index.ts
@@ -2,7 +2,7 @@ import { instance } from '@/shared/api'
 import { Schedule, ScheduleResponse } from './types'
 
 export const getCalendarList = async (currentYear: number, currentMonth: number): Promise<ScheduleResponse[]> => {
-  const res = await instance.get(`/schedule/user`, {
+  const res = await instance.get(`/schedule/couple`, {
     params: {
       year: currentYear,
       month: currentMonth,

--- a/src/features/calendar/lib/utils.ts
+++ b/src/features/calendar/lib/utils.ts
@@ -1,6 +1,7 @@
 import { ScheduleResponse } from '@/entities/calendar/api/types'
 import {
   addDays,
+  differenceInDays,
   differenceInMinutes,
   endOfDay,
   endOfMonth,
@@ -107,4 +108,9 @@ export const trancateString = (str: string, maxLength: number) => {
     return str.slice(0, maxLength) + '..'
   }
   return str
+}
+
+// 하루짜리 일정인지 확인
+export const isShortPlan = (startDate: string, endDate: string) => {
+  return isSameDay(startDate, endDate)
 }

--- a/src/features/calendar/lib/utils.ts
+++ b/src/features/calendar/lib/utils.ts
@@ -5,7 +5,7 @@ import {
   endOfDay,
   endOfMonth,
   getDay,
-  isEqual,
+  isSameDay,
   isToday,
   isWithinInterval,
   startOfDay,
@@ -83,9 +83,9 @@ export const getOneDaySchedule = (schedules: ScheduleResponse[], date: string | 
   )
 }
 
-// 각 plan이 하루가 넘어가는 일정이면 시작하는 날짜에만 title을 보여준다.
-export const isStartDate = (startDate: string, date: Date) => {
-  return isEqual(startDate, date)
+// 오늘이 일정 시작일인지 체크
+export const isStartDate = (startDate: string, today: Date) => {
+  return isSameDay(startDate, today)
 }
 
 // 1. 일정 시작일이 빠른 순서로 정렬

--- a/src/views/calendar/ui/Calendar/Calendar.tsx
+++ b/src/views/calendar/ui/Calendar/Calendar.tsx
@@ -40,14 +40,15 @@ export function CalendarPage() {
     navigateAddCalendar()
   }
 
-  if (isLoading) return <LoadingSpinner />
   if (isError) alert(error)
   return (
     currentDate && (
       <div className="h-calc64 relative flex flex-col bg-gray-50">
         <CalendarHeader />
-        <CalendarBody />
-        {/* <CalendarPlans /> */}
+        {/* LoadingSpinner -> 스켈레톤 UI 처리 예정 */}
+        {isLoading && <LoadingSpinner />}
+        {!isLoading && <CalendarBody />}
+
         {/* 스케쥴 추가 버튼 */}
         <div
           className="absolute bottom-[2rem] right-[1.5rem] cursor-pointer"

--- a/src/views/calendar/ui/Calendar/ScheduleList.tsx
+++ b/src/views/calendar/ui/Calendar/ScheduleList.tsx
@@ -3,6 +3,7 @@ import { COLORS } from '@/entities/calendar/consts/constants'
 import {
   getOneDaySchedule,
   getSortedOneDaySchedule,
+  isStartDate,
   trancateString,
 } from '@/features/calendar/lib/utils'
 import { useMemo } from 'react'
@@ -61,13 +62,20 @@ const ScheduleList = ({ date }: ScheduleList) => {
             key={plan.id}
             className="absolute h-1/4 text-[0.5rem] text-ellipsis overflow-hidden w-full whitespace-nowrap px-[0.5rem] text-sm"
             style={{
-              top: `calc(${25 * checkIndex(plan.index)}% + ${2 * checkIndex(plan.index) + 2}px)`,
+              top: (() => {
+                const idx = checkIndex(plan.index)
+                return `calc(${25 * idx}% + ${2 * idx + 2}px)`
+              })(),
               backgroundColor: COLORS[plan.color as keyof typeof COLORS] || COLORS['LIGHT_PURPLE']
             }}
           >
             <div>
               <span>
-                {trancateString(plan.title, 7)}
+                {/* 각 plan이 하루가 넘어가는 일정이면 시작하는 날짜에만 title을 보여준다. */}
+                {isStartDate(plan.startDateTime, date) && trancateString(plan.title, 7)}
+
+                {/* index가 재조정 되는 경우 재조정된 일자에만 title을 보여준다다 */}
+                {plan.index !== checkIndex(plan.index) && trancateString(plan.title, 7)}
               </span>
             </div>
           </li>

--- a/src/views/calendar/ui/Calendar/ScheduleList.tsx
+++ b/src/views/calendar/ui/Calendar/ScheduleList.tsx
@@ -3,6 +3,7 @@ import { COLORS } from '@/entities/calendar/consts/constants'
 import {
   getOneDaySchedule,
   getSortedOneDaySchedule,
+  isShortPlan,
   isStartDate,
   trancateString,
 } from '@/features/calendar/lib/utils'
@@ -65,11 +66,18 @@ const ScheduleList = ({ date }: ScheduleList) => {
               top: (() => {
                 const idx = checkIndex(plan.index)
                 return `calc(${25 * idx}% + ${2 * idx + 2}px)`
-              })(),
-              backgroundColor: COLORS[plan.color as keyof typeof COLORS] || COLORS['LIGHT_PURPLE']
+              })()
             }}
           >
-            <div>
+            {/* 배경색을 위한 div - 하루짜리 일정이면 10%, 아니면 100% 너비 */}
+            <div
+              className="absolute h-full top-0 left-0"
+              style={{
+                width: isShortPlan(plan.startDateTime, plan.endDateTime) ? '5%' : '100%',
+                backgroundColor: COLORS[plan.color as keyof typeof COLORS] || COLORS['LIGHT_PURPLE']
+              }}
+            />
+            <div className="relative z-10">
               <span>
                 {/* 각 plan이 하루가 넘어가는 일정이면 시작하는 날짜에만 title을 보여준다. */}
                 {isStartDate(plan.startDateTime, date) && trancateString(plan.title, 7)}


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제가 무엇인가요?

- 캘린더 UI 업데이트
  - 하루짜리 일정은 배경색의 width 5% 로 변경
  - 하루가 넘어가는 일정 시작일자에만 title UI 
  - index 재조정 건의 경우엔 title UI 추가 적용 필요 (아래 파란색 highlight인 2222 _6~8일 일정) 
  <img src="https://github.com/user-attachments/assets/e271f469-c19e-417a-ae34-0fae9ed4eb70" width="400" />


- 캘린더 커플 스케쥴 공유 안되는 버그 픽스

- 브라우저 다크 모드 시 font 색상이 안보이는 UI 버그 픽스

- refresh token 재발급 버그 픽스

## 🙏 Reviewer 분들이 이런 부분을 신경써서 봐 주시면 좋겠어요

> 개발 과정에서 다른 분들의 의견은 어떠한지 궁금했거나 크로스 체크가 필요하다고 느껴진 코드가 있다면 남겨주세요

- refresh token 재발급 로직이 제대로 관리되고 있지 못한 것 같습니다. 추천할 만한 refresh token 사용법이 있는지 궁금해요ㅠ
- ex) 현업에서 사용하는 코드 or 테스트 코드로 분기별 로직 확인 등
